### PR TITLE
Fix mention input dropdown closing behavior

### DIFF
--- a/components/mention-input.tsx
+++ b/components/mention-input.tsx
@@ -98,17 +98,21 @@ export default function MentionInput() {
     const afterMention = inputValue.substring(cursorPosition)
 
     // Insert the mention
-    const newValue = `${beforeMention}@${user.username} ${afterMention}`
+    const insertion = `@${user.username} `
+    const newValue = `${beforeMention}${insertion}${afterMention}`
     setInputValue(newValue)
+
+    // Calculate new cursor position before resetting the mention index
+    const newCursorPos = beforeMention.length + insertion.length
 
     // Reset mention state
     setShowMentions(false)
     mentionStartIndex.current = -1
+    setMentionFilter("")
 
     // Focus back on textarea and set cursor position after the inserted mention
     if (textareaRef.current) {
       textareaRef.current.focus()
-      const newCursorPos = mentionStartIndex.current + user.username.length + 2 // +2 for @ and space
       setTimeout(() => {
         if (textareaRef.current) {
           textareaRef.current.selectionStart = newCursorPos


### PR DESCRIPTION
## Summary
- ensure the cursor moves to the end of the inserted mention
- reset mention filter after selection

## Testing
- `npm run lint` *(fails: next not found)*